### PR TITLE
Update wpml-config.xml for Mix and Match 2

### DIFF
--- a/woocommerce-mix-and-match-products/wpml-config.xml
+++ b/woocommerce-mix-and-match-products/wpml-config.xml
@@ -1,15 +1,19 @@
-<wpml-config>
+<wpml-config>    
     <custom-fields>
         <custom-field action="copy">_mnm_base_price</custom-field>
         <custom-field action="copy">_mnm_base_regular_price</custom-field>
         <custom-field action="copy">_mnm_base_sale_price</custom-field>
+        <custom-field action="copy">_mnm_layout_override</custom-field>
         <custom-field action="copy">_mnm_layout_style</custom-field>
         <custom-field action="copy">_mnm_add_to_cart_form_location</custom-field>
         <custom-field action="copy">_mnm_min_container_size</custom-field>
         <custom-field action="copy">_mnm_max_container_size</custom-field>
-        <custom-field action="copy">_mnm_data</custom-field>
         <custom-field action="copy">_mnm_per_product_pricing</custom-field>
         <custom-field action="copy">_mnm_per_product_discount</custom-field>
+        <custom-field action="copy">_mnm_packing_mode</custom-field>
+        <custom-field action="copy">_mnm_weight_cumulative</custom-field>
+        <custom-field action="copy">_mnm_content_source</custom-field>
+        <custom-field action="copy">_mnm_data</custom-field>
         <custom-field action="copy">_mnm_per_product_shipping</custom-field>
     </custom-fields>
 </wpml-config>


### PR DESCRIPTION
Copy new meta fields that were added in MNM 2.0. Follow up to compat code: https://git.onthegosystems.com/glue-plugins/wpml/woocommerce-multilingual/-/merge_requests/1674